### PR TITLE
docs: add issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,42 @@
+name: Bug report
+description: Create a bug report to help us address errors in the repository
+title: "[BUG] <bug description>"
+labels: [bug]
+body:
+  - type: textarea
+    id: bugdescription
+    attributes:
+      label: Description of the bug
+    validations:
+      required: true
+  - type: input
+    id: stack
+    attributes:
+      label: Project stack or language (e.g. front-end)
+    validations:
+      required: true
+  - type: textarea
+    id: workingenvironment
+    attributes:
+      label: Working Environment (e.g. operating system, browser, device)
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Please add screenshots (if applicable)
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Add any other context about the problem here
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        Join our Discord Community [here](https://discord.gg/ceMXzhfaka)
+        Follow us on LinkedIn [here](https://www.linkedin.com/company/devs-dungeon)
+        Follow us on Twitter [here](https://twitter.com/devs_dungeon)
+        Feel free to check out other cool repositories of the DEVs Dungeon Community [here](https://github.com/Devs-Dungeon)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,30 @@
+name: Ideas
+description: Have a new idea or feature request
+title: "[FEATURE REQUEST] <description here>"
+labels: [enhancement]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description of feature request, idea
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Add (multiple) screenshot links (if applicable)
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Add any other context about the feature request here
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        Join our Discord Community [here](https://discord.gg/ceMXzhfaka)
+        Follow us on LinkedIn [here](https://www.linkedin.com/company/devs-dungeon)
+        Follow us on Twitter [here](https://twitter.com/devs_dungeon)
+        Feel free to check out other cool repositories of the DEVs Dungeon Community [here](https://github.com/Devs-Dungeon)

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,0 +1,29 @@
+name: Other
+description: Use this for any other issues. PLEASE do not create blank issues
+title: "[OTHER]"
+labels: [triage]
+body:
+  - type: markdown
+    attributes:
+      value: "# Other issue"
+  - type: textarea
+    id: issuedescription
+    attributes:
+      label: What would you like to share?
+      description: Provide a clear and concise explanation of your issue.
+    validations:
+      required: true
+  - type: textarea
+    id: extrainfo
+    attributes:
+      label: Additional information
+      description: Is there anything else we should know about this issue?
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        Join our Discord Community [here](https://discord.gg/ceMXzhfaka)
+        Follow us on LinkedIn [here](https://www.linkedin.com/company/devs-dungeon)
+        Follow us on Twitter [here](https://twitter.com/devs_dungeon)
+        Feel free to check out other cool repositories of the DEVs Dungeon Community [here](https://github.com/Devs-Dungeon)


### PR DESCRIPTION
Things added/changed:

- Add issue forms.
  - The issue forms were taken from the [support](https://github.com/Devs-Dungeon/support/) repository.
  - These issue forms (now that they are added here), will be used as a base for all the other repositories. Repositories that have issue forms will not be replaced by these ones.
  - CC: @TheSuranaverse.
